### PR TITLE
Avoiding a bug in limpiar_repeat_chars & adding shorthands

### DIFF
--- a/R/limpiar_repeat_chars.R
+++ b/R/limpiar_repeat_chars.R
@@ -15,7 +15,7 @@
 #'
 limpiar_repeat_chars <- function(df, text_var = mention_content){
   #Checks there is a j + (e or i or a) and at least characters made from j + a i e.
-  laughing_regex <- "(?=.+j)((?=.+j)|(?=.+a)|(?=.+e)|(?=.+i))[(j|a|i|e)+(j|a|i|e)+]{4,}"
+  laughing_regex <- "\\b(?=.+j)((?=.+j)|(?=.+a)|(?=.+e)|(?=.+i))[(j|a|i|e)+(j|a|i|e)+]{4,}"
   #Replaces messy laughing strings with "jaja"
   laughing_replacement <- "jaja"
 

--- a/R/limpiar_shorthands.R
+++ b/R/limpiar_shorthands.R
@@ -26,7 +26,8 @@ limpiar_shorthands <- function(df, text_var = mention_content, spaces_as_undersc
                   "\\b(NPN|npn)\\b", "\\bvrd\\b", "\\bvdd\\b", "\\bntp\\b", "\\b(GPI|gpi)\\b", "\\bslds\\b", "\\bctm\\b",
                   "\\bgrax\\b", "\\bwn\\b", "\\basdc\\b", "\\b100pre\\b", "\\b(k|q) aces\\b", "\\bsbs\\b",
                   "\\bvns\\b", "\\baora\\b", "\\bbn\\b", "\\bnx\\b","\\bcdo\\b", "\\bdim\\b",
-                  "\\bdcr\\b", "\\bkntm\\b", "\\bnph\\b", "\\bre100\\b", "\\btvo\\b", "\\bweno\\b", "\\bbb\\b", "\\bntonces","\\Bporfavor")
+                  "\\bdcr\\b", "\\bkntm\\b", "\\bnph\\b", "\\bre100\\b", "\\btvo\\b", "\\bweno\\b", "\\bbb\\b", "\\bntonces","\\Bporfavor",
+                  "\\beske\\b")
 
   shorthand_corrections <- c("porque", "te_quiero_mucho", "te_quiero", "porque", "porque", "que", "que",
                              "porque", "porque", "por_favor", "para_que", "mucho", "besitos",
@@ -35,7 +36,7 @@ limpiar_shorthands <- function(df, text_var = mention_content, spaces_as_undersc
                              "no_pasa_nada", "verdad", "verdad", "no_te_preocupes", "gracias_por_invitar",
                              "saludos", "chinga_tu_madre", "gracias", "wuevon", "a_salir_de_casa", "siempre",
                              "que haces", "sabes", "vienes", "ahora", "bien", "buenas noches", "cuando", "dime",
-                             "decir", "cuentame", "no_puedo_hablar", "recien", "te_veo", "bueno", "bebe", "entonces", "porfavor")
+                             "decir", "cuentame", "no_puedo_hablar", "recien", "te_veo", "bueno", "bebe", "entonces", "porfavor", "es que")
   if(spaces_as_underscores){
     shorhand_corrections <- shorthand_corrections
   }else{

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 LimpiaR is an R library of pre-processing functions for text data.
 
-For non-Spanish speakers, limpiar is a Spanish verb and translates in English to 'to clean'. So generally, when you're calling a LimpiaR function, you can think of it as 'clean...'
+Limpiar is a Spanish verb and translates in English to 'to clean'. So generally, when you're calling a LimpiaR function, you can think of it as 'clean...'
 
-LimpiaR is primarily used for cleaning messy text-data, such as that which comes from social media or reviews. In its initial release, it is focused around the Spanish language, but some of its functions are language-ambivalent. 
+LimpiaR is primarily used for cleaning messy text-data, such as that which comes from social media or reviews. In its initial release, it is focused around the Spanish language, however, some of its functions are language-ambivalent. 
 
 
 ## Installing the package


### PR DESCRIPTION
Added word boundary to limpiar_repeat_chars, to avoid words like viej…a being replaced by 'vjaja'

added shorthands to limpiar_shorthands